### PR TITLE
Annotator author distinction

### DIFF
--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/ajax.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/ajax.js
@@ -13,12 +13,14 @@ var AjaxCalls = function(args){
 	const save_url = (project, file) => ['/api','close_reading', 'project', project, 'file', file, 'save/'].join('/');
 	const history_url = (project, file, version) => ['/api','close_reading','project', project, 'file', file,'version', version, 'history/'].join('/');
 	const search_url = (project, entity_type, query) => ['/api/search/entity_completion/project',project,'entity',entity_type,query].join('/');
+	const user_url = (project, entity_type, query) => '/api/close_reading/current_user/';
 
 	function _init(args){
 		const obj = {
 			safeFile: (project, file) => _createCall('PUT', base_url + save_url(project, file)),
 			getHistory: (project, file, version) => _createCall('GET', base_url + history_url(project, file, version)),
-			getAutocomplete: (project, entity_type, query) => _createCall('GET', base_url + search_url(project, entity_type, query))
+			getAutocomplete: (project, entity_type, query) => _createCall('GET', base_url + search_url(project, entity_type, query)),
+			getUser: () => _createCall('GET', base_url + user_url())
 		};
 
 		return obj;

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/ajax.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/ajax.js
@@ -41,7 +41,6 @@ var AjaxCalls = function(args){
 		    return cookieValue;
 		}
 
-		console.log(url)
 		const csrftoken = getCookie('csrftoken');
 
 		return new Promise(function(resolve, cancel){


### PR DESCRIPTION
This branch implements the needed changes to distinguish between one's annotations
and another user's uncertainty annotations.

Styles are applied after the API answers with the current user, which is then compared
to each uncertainty annotation's `resp` attribute.

