### PR TITLE
Merge Fix/annotator flexible taxonomy. Closes #14 #11 

### DIFF
--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/app.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/app.js
@@ -37,12 +37,3 @@ websocket.addCallback('onreload', ()=>Alert.alert('success','Changes successfull
 
 // Create websocket
 websocket.create();
-
-/*sub.publish('popup/render', {
-	title: 'alex',
-	subtitle: 'holaaaaaa',
-	body: 'ajdjasjd asjd as dsv j esrdfvkj re adsvcneroijvdv eñdskfnv',
-	x: '300px',
-	y: '150px'
-})
-setTimeout(()=>sub.publish('popup/hide', {}), 3000);*/

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/app.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/app.js
@@ -26,6 +26,7 @@ const tooltips = Tooltips({channel});
 const sub = {};
 channel.addToChannel(sub);
 sub.subscribe('websocket/send', json=>websocket.send(json));
+sub.subscribe('websocket/send', json=>console.log(json));
 sub.subscribe('document/render', selection=>console.info('Document rendered.'));
 
 // Publish websocket updates

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/annotator.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/annotator.js
@@ -55,7 +55,7 @@ var Annotator = function(args){
 	        return
 
 	    const data = {
-            "categories": [args.category,],
+            "categories": args.categories,
             "locus": args.locus,
             "certainty": args['cert-level'],
             "description": args.desc,

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/panel.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/panel.js
@@ -126,6 +126,8 @@ let PanelView = function(args){
 	}
 
 	function _getCurrentValues(args){
+		const getAllSelected = selectInput=>Array.from(selectInput.options).reduce((ac,dc)=>dc.selected?[...ac,dc.value]:ac,[]);
+
 		const options = {
 			'annotating-uncertainty': document
 				.getElementById('annotating-uncertainty')
@@ -141,13 +143,14 @@ let PanelView = function(args){
 			'locus': document.getElementById('locus').value,
 			'tag-name': document.getElementById('tag-name').value,
 			'attribute-name': document.getElementById('attribute-name').value,
-			'category': document.getElementById('category').value,
+			'categories': getAllSelected(document.getElementById('category')),
 			'asserted-value': document.getElementById('asserted-value-container').getElementsByClassName('input')[0].value,
 			'references': document.getElementById('references').value,
 			'references-filepath': document.getElementById('references').filepath,
 			'description': document.getElementById('description').value,
 			'tei-tag-name': document.getElementById('tei-tag-name').value,
 		};
+
 		return options;
 	}
 

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -7,7 +7,7 @@
  * Listens:
  * - panel/display_options
  * */
-import teiConf from './utilities/taxonomy.js';
+import ColorScheme from './utilities/color.js';
 
 var Popup = function(args){
 	let self = null;
@@ -85,7 +85,7 @@ var Popup = function(args){
  * */
 var Tooltips = function(args){
 	let self = null;
-	const tags = Object.keys(teiConf['entities']);
+	const tags = Object.keys(ColorScheme.scheme['entities']);
 
 	function _init(args){
 		const obj = {

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/ui.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/ui.js
@@ -2,7 +2,6 @@
  * View rendering form options, legends, and other ui 
  * elements based on the taxonomy configuration.
  * */
-import teiConf from './utilities/taxonomy.js';
 import ColorScheme from './utilities/color.js';
 
 let UISetup = function(args){
@@ -43,7 +42,7 @@ let UISetup = function(args){
   }
 
   function _createEntitiesFormOptions(){
-    const options = Object.entries(teiConf['entities']).map(e=>$.parseHTML(
+    const options = Object.entries(ColorScheme.scheme['entities']).map(e=>$.parseHTML(
       `<option value="${e[0]}">${e[0].slice(0,1).toUpperCase() + e[0].slice(1)}</option>`
       )[0]);
 
@@ -55,12 +54,12 @@ let UISetup = function(args){
       .getElementById('legend-sidebar');
 
     const entityEntries = Object
-      .entries(teiConf['entities'])
+      .entries(ColorScheme.scheme['entities'])
       .map(e=>_createEntityLegendEntry(e))
       .join('\n');
 
     const certEntries = Object
-      .entries(teiConf['taxonomy'])
+      .entries(ColorScheme.scheme['taxonomy'])
       .map(e=>_createCertLegendEntry(e))
       .join('\n');
     
@@ -122,7 +121,7 @@ let UISetup = function(args){
   }
 
   function _createDisplayStyles(){
-    let selectors = Object.keys(teiConf['entities']).map(e=>
+    let selectors = Object.keys(ColorScheme.scheme['entities']).map(e=>
       `div#annotator-root[color-annotations="false"] ${e}`).join(',\n');
     
     const colorRule = `
@@ -132,7 +131,7 @@ let UISetup = function(args){
       }
     `
 
-    selectors = Object.keys(teiConf['entities']).map(e=>
+    selectors = Object.keys(ColorScheme.scheme['entities']).map(e=>
       `div#annotator-root[display-annotations="true"] ${e}::before`).join(',\n');
     
     const displayRule = `
@@ -148,7 +147,7 @@ let UISetup = function(args){
       }
     `
 
-    selectors = Object.keys(teiConf['entities']).map(e=>
+    selectors = Object.keys(ColorScheme.scheme['entities']).map(e=>
       `div#annotator-root[display-annotations="false"] ${e}`).join(',\n');
     
     const hideRule = `
@@ -158,7 +157,7 @@ let UISetup = function(args){
       }
     `
 
-    selectors = Object.keys(teiConf['entities']).join(',');
+    selectors = Object.keys(ColorScheme.scheme['entities']).join(',');
     
     const tagRule = `
       ${selectors}
@@ -172,22 +171,22 @@ let UISetup = function(args){
     `
 
     const borderRules = Object
-      .entries(teiConf['entities'])
+      .entries(ColorScheme.scheme['entities'])
       .map(e=>`${e[0]}{ border-color: ${e[1].color};}`)
       .join('\n');
 
     const entityFillRules = Object
-      .entries(teiConf['entities'])
+      .entries(ColorScheme.scheme['entities'])
       .map(e=>`.bg-${e[0]}{ background-color: ${e[1].color};}`)
       .join('\n');
 
     const entityIconRules = Object
-      .entries(teiConf['entities'])
+      .entries(ColorScheme.scheme['entities'])
       .map(e=>`div#annotator-root[display-annotations="true"] ${e[0]}::before{ content: "${e[1].icon}";}`)
       .join('\n');
 
     const entityIconColorRules = Object
-      .entries(teiConf['entities'])
+      .entries(ColorScheme.scheme['entities'])
       .map(e=>`div#annotator-root[color-annotations="true"] ${e[0]}::before{ color: ${e[1].color};}`)
       .join('\n');
 
@@ -204,7 +203,7 @@ let UISetup = function(args){
   }
 
   function _createContentStyles(){
-    const selectors = Object.keys(teiConf['entities']).map(e=>
+    const selectors = Object.keys(ColorScheme.scheme['entities']).map(e=>
       `div#annotator-root[color-annotations="false"] ${e}`).join(',\n');
     
     const rule = `

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/ui.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/ui.js
@@ -39,10 +39,22 @@ let UISetup = function(args){
     select_form = document
       .getElementById('tei-tag-name');
     _createEntitiesFormOptions().forEach(opt=>select_form.appendChild(opt));
+
+    select_form = document
+      .getElementById('category');
+    _createCertFormOptions().forEach(opt=>select_form.appendChild(opt));
   }
 
   function _createEntitiesFormOptions(){
     const options = Object.entries(ColorScheme.scheme['entities']).map(e=>$.parseHTML(
+      `<option value="${e[0]}">${e[0].slice(0,1).toUpperCase() + e[0].slice(1)}</option>`
+      )[0]);
+
+    return options;
+  }
+
+  function _createCertFormOptions(){
+    const options = Object.entries(ColorScheme.scheme['taxonomy']).map(e=>$.parseHTML(
       `<option value="${e[0]}">${e[0].slice(0,1).toUpperCase() + e[0].slice(1)}</option>`
       )[0]);
 

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/color.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/color.js
@@ -3,10 +3,12 @@
  * or calculating the color for a specific annotation
  *
  * */
-import teiConf from './taxonomy.js';
+import defConf from './taxonomy.js';
 
 var ColorScheme = (function(args){
 	let self = null;
+
+	const teiConf = Object.assign(defConf, window.preferences);
 
 	const certaintyLevelTransparencies = {
 		high: 'ff',
@@ -28,7 +30,8 @@ var ColorScheme = (function(args){
 	}
 
 	return {
-		calculate: _applyColorScheme
+		calculate: _applyColorScheme,
+		scheme: teiConf
 	};
 })();
 

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/taxonomy.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/taxonomy.js
@@ -69,6 +69,15 @@ export default {
 		"time": {
 			"icon": "\\f017", 
 			"color": "#eab9e4"
-		}
+		},"ingredient": {
+			"icon": "\uf787", 
+			"color": "#395b50"
+		},"productionMethod": {
+			"icon": "\\f542", 
+			"color": "#291528"
+		},"utensil": {
+			"icon": "\uf6e3", 
+			"color": "#96031a"
+		},
 	}
 };

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/websocket.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/websocket.js
@@ -32,7 +32,7 @@ const AnnotatorWebSocket = function(){
         let wsPrefix = (window.location.protocol === 'https:') ? 'wss://' : 'ws://';
         let port = '';
 
-        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+        if (window.location.hostname === '0.0.0.0' || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
         {
             port = ':' + window.location.port
         }

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -264,6 +264,7 @@
     window.project_id = "{{ project_id }}";
     window.file_id = "{{ file_id }}";
     window.file_version = "{{ file.version_number }}";
+    window.preferences = JSON.parse("{{ preferences|escapejs|safe }}");
   </script>
   <script src="https://d3js.org/d3.v5.min.js"></script>
   <script type="module" src="{% static 'close_reading/js/app.js' %}"></script>

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -182,9 +182,11 @@
                                   </label>
                                   <select class="form-control form-control-sm" id='cert-level'>
                                     <option value="unknown">Unknown</option>
+                                    <option value="very high">Very high</option>
                                     <option value="high">High</option>
                                     <option value="medium">Medium</option>
                                     <option value="low">Low</option>
+                                    <option value="very low">Very low</option>
                                   </select>
                                 </div>
                               </div>

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -126,10 +126,6 @@
                                     <span class="help-tooltip" help="This is the category." />
                                   </label>
                                   <select multiple class="form-control form-control-sm" id='category'>
-                                    <option class="ignorance" value="ignorance">Ignorance</option>
-                                    <option class="credibility" value="credibility">Credibility</option>
-                                    <option class="imprecision" value="imprecision">Imprecision</option>
-                                    <option class="incompleteness" value="incompleteness">Incompleteness</option>
                                   </select>
                                 </div>
                                 <div class="col">

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -125,7 +125,7 @@
                                   <label for="category">Category of uncertainty 
                                     <span class="help-tooltip" help="This is the category." />
                                   </label>
-                                  <select class="form-control form-control-sm" id='category'>
+                                  <select multiple class="form-control form-control-sm" id='category'>
                                     <option class="ignorance" value="ignorance">Ignorance</option>
                                     <option class="credibility" value="credibility">Credibility</option>
                                     <option class="imprecision" value="imprecision">Imprecision</option>

--- a/src/collaborative_platform/apps/close_reading/views.py
+++ b/src/collaborative_platform/apps/close_reading/views.py
@@ -1,4 +1,5 @@
 import re
+import json
 from urllib.parse import urlparse
 from django.http import HttpResponse, HttpRequest
 from django.shortcuts import render
@@ -30,6 +31,24 @@ def close_reading(request, project_id, file_id):  # type: (HttpRequest, int, int
     
     origin = resolve_match.url_name
 
+    preferences = { 'taxonomy':{ }}
+    preferences['taxonomy'][file.project.taxonomy.name_1] = {
+        'color': file.project.taxonomy.color_1,
+        'desc': file.project.taxonomy.desc_1
+    }
+    preferences['taxonomy'][file.project.taxonomy.name_2] = {
+        'color': file.project.taxonomy.color_2,
+        'desc': file.project.taxonomy.desc_2
+    }
+    preferences['taxonomy'][file.project.taxonomy.name_3] = {
+        'color': file.project.taxonomy.color_3,
+        'desc': file.project.taxonomy.desc_3
+    }
+    preferences['taxonomy'][file.project.taxonomy.name_4] = {
+        'color': file.project.taxonomy.color_4,
+        'desc': file.project.taxonomy.desc_4
+    }
+
     context = {
         'origin': origin,
         'origin_url': origin_url,
@@ -38,6 +57,7 @@ def close_reading(request, project_id, file_id):  # type: (HttpRequest, int, int
         'file': file,
         'project_id': project_id,
         'file_id': file_id,
+        'preferences': json.dumps(preferences)
     }
 
     return render(request, 'close_reading/close_reading.html', context)


### PR DESCRIPTION
The following changes have been made to the annotator:
- Now the user can select multiple categories and assign _very low_ and _very high_ certainty levels.
- Now the specified taxonomy and color scheme is used.

**Note that in order to select multiple categories the [Ctrl] key must be pressed as it
is specified in HTML5**

An example of annotation request with the new functionality is the following:
```
{"categories":["ignorance","imprecision"],"locus":"value","certainty":"very high","tag":"date","start_pos":6352,"end_pos":6352,"asserted_value":"lemon"}
```

Another example is the following, where no categories have been selected (as said in #11):
```
{"categories":[],"locus":"value","certainty":"very high","tag":"date","start_pos":6352,"end_pos":6352,"asserted_value":"lemon"}
```

Following is a screenshot of how the UI shows now.
![image](https://user-images.githubusercontent.com/28607713/70077298-d6eeb280-1600-11ea-9127-46cd5eac1a05.png)