### PR TITLE
Fix/annotator selection

### DIFF
--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/document_view.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/document_view.js
@@ -179,6 +179,12 @@ var DocumentView = function(args){
 	        end_content = end_content.replace(_expandedEmptyTag(empty_tag), empty_tag);
 	    }
 
+	    /* Browsers will now add the xmlns attribute nonetheless to
+	       make sure that the markup is representative of the namespaces.
+	       This breaks the ability to compare with the initial content. */
+	    start_content = start_content.replace(/ xmlns="http:\/\/www.tei-c.org\/ns\/1.0"/g, '');
+	    end_content = end_content.replace(/ xmlns="http:\/\/www.tei-c.org\/ns\/1.0"/g, '');
+
 	    const positions = [];
 
 	    for(let i=0; i<start_content.length; i++){

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/document_view.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/document_view.js
@@ -121,15 +121,16 @@ var DocumentView = function(args){
 	                		node._uncertainty_count += 1;
 	                	}
 
-
-                        addStyle(
-                            XML_EXTRA_CHAR_SPACER+target.slice(1), 
-                            annotation.attributes['category'].value, 
-                            annotation.attributes['cert'].value,
-                            annotation.attributes['resp'].value,
-                            currentUser,
-                            node._uncertainty_count
-                            );
+	                	if(annotation.attributes.hasOwnProperty('category')){
+	                        addStyle(
+	                            XML_EXTRA_CHAR_SPACER+target.slice(1), 
+	                            annotation.attributes['category'].value, 
+	                            annotation.attributes['cert'].value,
+	                            annotation.attributes['resp'].value,
+	                            currentUser,
+	                            node._uncertainty_count
+	                            );
+	                	}
                     }
                 })
             });


### PR DESCRIPTION
Browsers add an `xmlns` tag to make sure that the markup is representative. This
was not done when tags were removed from the parsed XML file, however I see that
now this can't be avoided.

I handle this now at the time of making selections so that the absolute positions do 
not take that artificial text into account.