### PR TITLE
Append unifications from database to message sent to Annotator by WebSocket

### DIFF
--- a/src/collaborative_platform/apps/api_vis/api.py
+++ b/src/collaborative_platform/apps/api_vis/api.py
@@ -295,7 +295,7 @@ def project_cliques(request, project_id):  # type: (HttpRequest, int) -> HttpRes
                         created_by=request.user,
                         certainty=request_data['certainty'],
                         created_in_file_version=file_version,
-                        xml_id_number=file_max_xml_ids.certainty,
+                        xml_id=f'certainty_{entity.file.name}-{file_max_xml_ids.certainty}',
                     )
 
                     unification_statuses[i].update({
@@ -535,7 +535,7 @@ def clique_entities(request, project_id, clique_id):  # type: (HttpRequest, int,
                             created_by=request.user,
                             certainty=request_data['certainty'],
                             created_in_file_version=file_version,
-                            xml_id_number=file_max_xml_ids.certainty,
+                            xml_id=f'certainty_{entity.file.name}-{file_max_xml_ids.certainty}',
                         )
                     else:
                         raise NotModified(f"This entity already exist in clique with id: {clique_id}")

--- a/src/collaborative_platform/apps/api_vis/models.py
+++ b/src/collaborative_platform/apps/api_vis/models.py
@@ -101,7 +101,7 @@ class Unification(models.Model):
     deleted_in_file_version = models.ForeignKey(FileVersion, default=None, null=True, blank=True,
                                                 on_delete=models.CASCADE)
     certainty = models.CharField(max_length=10)
-    xml_id_number = models.IntegerField(default=None, null=True)
+    xml_id = models.CharField(max_length=255)
 
 
 class CliqueToDelete(models.Model):
@@ -116,3 +116,15 @@ class UnificationToDelete(models.Model):
     deleted_by = models.ForeignKey(User, on_delete=models.CASCADE)
     deleted_on = models.DateTimeField(auto_now=True)
     project_version = models.ForeignKey(ProjectVersion, on_delete=models.CASCADE)
+
+
+class Certainty(models.Model):
+    ana = models.CharField(max_length=255)
+    locus = models.CharField(max_length=255)
+    cert = models.CharField(max_length=255)
+    asserted_value = models.CharField(max_length=255, null=True)
+    resp = models.CharField(max_length=255)
+    target = models.CharField(max_length=255)
+    xml_id = models.CharField(max_length=255)
+    description = models.CharField(max_length=255, null=True)
+    unification = models.ForeignKey(Unification, related_name='certainties', on_delete=models.CASCADE)

--- a/src/collaborative_platform/apps/close_reading/helpers.py
+++ b/src/collaborative_platform/apps/close_reading/helpers.py
@@ -1,9 +1,3 @@
-import xmltodict
-import json
-
-from lxml import etree
-
-from apps.api_vis.models import Unification
 from apps.files_management.models import File
 
 
@@ -17,30 +11,3 @@ def verify_reference(file_id, asserted_value):
         asserted_value = '#' + person_id
 
     return asserted_value
-
-
-def unification_xml_elements_to_json(unifications):
-    unifications_to_return = []
-
-    for unification in unifications:
-        unification = etree.tostring(unification, encoding='utf-8')
-        parsed_unification = xmltodict.parse(unification)
-
-        del parsed_unification['certainty']['@xmlns']
-
-        entity_xml_id = parsed_unification['certainty']['@target'][1:]
-        xml_id_number = int(parsed_unification['certainty']['@xml:id'].split('-')[-1])
-
-        unification__in_db = Unification.objects.get(
-            entity__xml_id=entity_xml_id,
-            xml_id_number=xml_id_number,
-            deleted_on__isnull=True,
-        )
-
-        parsed_unification['committed'] = True if unification__in_db.created_in_commit else False
-
-        unifications_to_return.append(parsed_unification)
-
-    unifications_to_return = json.dumps(unifications_to_return)
-
-    return unifications_to_return

--- a/src/collaborative_platform/apps/close_reading/models.py
+++ b/src/collaborative_platform/apps/close_reading/models.py
@@ -13,6 +13,7 @@ class RoomPresence(models.Model):
     room_symbol = models.CharField(max_length=255)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     timestamp = models.DateTimeField(auto_now=True)
+    channel_name = models.CharField(max_length=255)
 
 
 class AnnotationHistory(models.Model):

--- a/src/collaborative_platform/apps/files_management/helpers.py
+++ b/src/collaborative_platform/apps/files_management/helpers.py
@@ -262,7 +262,6 @@ def create_certainty_elements_for_file_version(file_version, include_uncommitted
         unifications = Unification.objects.filter(
             clique=clique,
             deleted_on__isnull=True,
-            created_in_commit__isnull=False,
         )
 
         if include_uncommitted:


### PR DESCRIPTION
Because now we keep all entity unifications and certainties added to this unifications in database instead of xml file, we need to render this elements in Annotator additionally. In this modification I update backend side by extending a message sent by WebSockets by one more field `certainties_from_db`, with list of unifications and certainties inside. Every unification/certainty has extra boolean field `committed`. Committed unifications and certainties for them are sent to all connected users, and uncommitted unifications and certainties for them are sent only to theirs author.