### PR TITLE
Reimplement unification of entities in Annotator

### DIFF
--- a/src/collaborative_platform/apps/api_vis/helpers.py
+++ b/src/collaborative_platform/apps/api_vis/helpers.py
@@ -619,7 +619,8 @@ def common_filter_entities(query_string, project_id):
     return entities_to_return
 
 
-def create_clique(request_data, project_id, user):  # type: (dict, int, User) -> (Clique, list)
+def create_clique(request_data, project_id, user, created_in_annotator=False):
+    # type: (dict, int, User, bool) -> (Clique, list)
     from apps.api_vis.api import ENTITY_CLASSES
 
     if 'name' in request_data and request_data['name'] != '':
@@ -636,6 +637,7 @@ def create_clique(request_data, project_id, user):  # type: (dict, int, User) ->
         asserted_name=clique_name,
         created_by=user,
         project_id=project_id,
+        created_in_annotator=created_in_annotator,
     )
 
     file_version_counter, commit_counter = parse_project_version(request_data['project_version'])
@@ -686,6 +688,7 @@ def create_clique(request_data, project_id, user):  # type: (dict, int, User) ->
                 created_by=user,
                 certainty=request_data['certainty'],
                 created_in_file_version=file_version,
+                created_in_annotator=created_in_annotator,
                 xml_id=f'certainty_{entity.file.name}-{file_max_xml_ids.certainty}',
             )
 

--- a/src/collaborative_platform/apps/api_vis/helpers.py
+++ b/src/collaborative_platform/apps/api_vis/helpers.py
@@ -4,15 +4,15 @@ import re
 from datetime import datetime
 from lxml import etree
 
-from django.http import HttpRequest, JsonResponse
+from django.http import HttpResponseBadRequest, HttpRequest, JsonResponse
 from django.contrib.auth.models import User
 
 import apps.index_and_search.models as es
 
-from apps.api_vis.models import Commit, Entity, EventVersion, OrganizationVersion, PersonVersion, PlaceVersion, \
+from apps.api_vis.models import Clique, Commit, Entity, EventVersion, OrganizationVersion, PersonVersion, PlaceVersion, \
     CertaintyVersion, Unification
 from apps.exceptions import BadRequest
-from apps.files_management.models import File, FileVersion, Directory
+from apps.files_management.models import Directory, File, FileMaxXmlIds, FileVersion
 from apps.projects.models import Project, ProjectVersion
 
 
@@ -255,8 +255,12 @@ def get_file_id_from_path(project_id, file_path, parent_directory_id=None):  # t
         file_name = splitted_path[0]
 
         try:
-            file = File.objects.get(project_id=project_id, parent_dir_id=parent_directory_id, name=file_name,
-                                    deleted=False)
+            file = File.objects.get(
+                project_id=project_id,
+                parent_dir_id=parent_directory_id,
+                name=file_name,
+                deleted=False
+             )
 
             return file.id
 
@@ -280,7 +284,11 @@ def get_file_id_from_path(project_id, file_path, parent_directory_id=None):  # t
 def get_entity_from_int_or_dict(request_entity, project_id):
     if type(request_entity) == int:
         try:
-            entity = Entity.objects.get(id=request_entity, project_id=project_id)
+            entity = Entity.objects.get(
+                id=request_entity,
+                project_id=project_id
+            )
+
             return entity
 
         except Entity.DoesNotExist:
@@ -300,7 +308,12 @@ def get_entity_from_int_or_dict(request_entity, project_id):
         file_id = get_file_id_from_path(project_id, file_path)
 
         try:
-            entity = Entity.objects.get(file_id=file_id, xml_id=xml_id)
+            entity = Entity.objects.get(
+                project_id=project_id,
+                file_id=file_id,
+                xml_id=xml_id,
+                deleted_on__isnull=True
+            )
 
             return entity
 
@@ -604,3 +617,89 @@ def common_filter_entities(query_string, project_id):
         entities_to_return.append(entity_to_return)
 
     return entities_to_return
+
+
+def create_clique(request_data, project_id, user):  # type: (dict, int, User) -> (Clique, list)
+    from apps.api_vis.api import ENTITY_CLASSES
+
+    if 'name' in request_data and request_data['name'] != '':
+        clique_name = request_data['name']
+    elif len(request_data['entities']) > 0:
+        request_entity = request_data['entities'][0]
+        entity = get_entity_from_int_or_dict(request_entity, project_id)
+        entity_version = ENTITY_CLASSES[entity.type].objects.filter(entity=entity).order_by('-fileversion')[0]
+        clique_name = entity_version.name
+    else:
+        raise BadRequest(f"Missing name for a clique. Provide name in 'name' parameter or at least one entity.")
+
+    clique = Clique.objects.create(
+        asserted_name=clique_name,
+        created_by=user,
+        project_id=project_id,
+    )
+
+    file_version_counter, commit_counter = parse_project_version(request_data['project_version'])
+
+    try:
+        project_version = ProjectVersion.objects.get(
+            project_id=project_id,
+            file_version_counter=file_version_counter,
+            commit_counter=commit_counter,
+        )
+    except ProjectVersion.DoesNotExist:
+        raise BadRequest(f"Version: {request_data['project_version']} of project with id: {project_id} "
+                         f"doesn't exist.")
+
+    unification_statuses = []
+
+    for i, entity in enumerate(request_data['entities']):
+        if type(entity) == int:
+            unification_statuses.append({'id': entity})
+        else:
+            unification_statuses.append(entity)
+
+        try:
+            entity = get_entity_from_int_or_dict(entity, project_id)
+
+            try:
+                file_version = FileVersion.objects.get(
+                    projectversion=project_version,
+                    file=entity.file
+                )
+            except FileVersion.DoesNotExist:
+                raise BadRequest(f"Source file of entity with id: {entity.id} doesn't exist in version: "
+                                 f"{request_data['project_version']} of the project with id: {project_id}.")
+
+            if entity.created_in_version > file_version.number or \
+                    entity.deleted_in_version and entity.deleted_in_version < file_version.number:
+                raise BadRequest(f"Entity with id: {entity.id} doesn't exist in version: "
+                                 f"{request_data['project_version']} of the project with id: {project_id}.")
+
+            file_max_xml_ids = FileMaxXmlIds.objects.get(file=entity.file)
+            file_max_xml_ids.certainty += 1
+            file_max_xml_ids.save()
+
+            Unification.objects.create(
+                project_id=project_id,
+                entity=entity,
+                clique=clique,
+                created_by=user,
+                certainty=request_data['certainty'],
+                created_in_file_version=file_version,
+                xml_id=f'certainty_{entity.file.name}-{file_max_xml_ids.certainty}',
+            )
+
+            unification_statuses[i].update({
+                'status': 200,
+                'message': 'OK'
+            })
+
+        except BadRequest as exception:
+            status = HttpResponseBadRequest.status_code
+
+            unification_statuses[i].update({
+                'status': status,
+                'message': str(exception)
+            })
+
+    return clique, unification_statuses

--- a/src/collaborative_platform/apps/api_vis/models.py
+++ b/src/collaborative_platform/apps/api_vis/models.py
@@ -79,6 +79,7 @@ class Clique(models.Model):
     created_on = models.DateTimeField(auto_now_add=True)
     created_in_commit = models.ForeignKey(Commit, related_name="cliques", default=None, null=True, blank=True,
                                           on_delete=models.CASCADE)
+    created_in_annotator = models.BooleanField(default=False)
     deleted_by = models.ForeignKey(User, related_name="deleted_cliques", default=None, on_delete=models.SET_NULL,
                                    null=True)
     deleted_on = models.DateTimeField(null=True)
@@ -94,6 +95,7 @@ class Unification(models.Model):
     created_in_commit = models.ForeignKey(Commit, related_name="unifications", default=None, null=True, blank=True,
                                           on_delete=models.CASCADE)
     created_in_file_version = models.ForeignKey(FileVersion, related_name="unifications", on_delete=models.CASCADE)
+    created_in_annotator = models.BooleanField(default=False)
     deleted_by = models.ForeignKey(User, related_name="deleted_unifiactions", default=None, on_delete=models.SET_NULL,
                                    null=True)
     deleted_on = models.DateTimeField(null=True)

--- a/src/collaborative_platform/apps/close_reading/consumers.py
+++ b/src/collaborative_platform/apps/close_reading/consumers.py
@@ -97,7 +97,7 @@ class AnnotatorConsumer(WebsocketConsumer):
         )
 
         certainty_elements = create_certainty_elements_for_file_version(file_version, include_uncommitted=True,
-                                                                        user=self.scope['user'])
+                                                                        user=self.scope['user'], for_annotator=True)
         certainties_from_db = certainty_elements_to_json(certainty_elements)
 
         response = {
@@ -183,7 +183,8 @@ class AnnotatorConsumer(WebsocketConsumer):
 
                     certainty_elements = create_certainty_elements_for_file_version(file_version,
                                                                                     include_uncommitted=True,
-                                                                                    user=presence.user)
+                                                                                    user=presence.user,
+                                                                                    for_annotator=True)
                     certainties_from_db = certainty_elements_to_json(certainty_elements)
 
                     response = {

--- a/src/collaborative_platform/apps/files_management/file_conversions/file_type_finder.py
+++ b/src/collaborative_platform/apps/files_management/file_conversions/file_type_finder.py
@@ -22,7 +22,7 @@ class FileTypeFinder:
         except etree.XMLSyntaxError as err:
             logger.info("checking if xml: {}".format(err))
 
-            return FileType.OTHER
+            return FileType.PLAIN_TEXT
 
     def check_if_csv_or_tsv(self, text):
         fragment_to_check = text[:1024]
@@ -41,4 +41,4 @@ class FileTypeFinder:
         except Exception as ex:
             logger.info("checking if csv or tsv: {}".format(ex))
 
-            return FileType.OTHER
+            return FileType.PLAIN_TEXT

--- a/src/collaborative_platform/apps/files_management/file_conversions/migrator_plain_text.py
+++ b/src/collaborative_platform/apps/files_management/file_conversions/migrator_plain_text.py
@@ -1,0 +1,56 @@
+import re
+
+
+class MigratorPlainText:
+    def __init__(self):
+        pass
+
+    def migrate(self, text):  # type: (str) -> str
+        tei_beginning = self.__create_tei_p5_beginning()
+        tei_body = self.__convert_plain_text_to_tei_body(text)
+        tei_end = self.__create_tei_p5_end()
+
+        tei_file = tei_beginning + tei_body + tei_end
+
+        return tei_file
+
+    @staticmethod
+    def __create_tei_p5_beginning():  # type: () -> str
+        tei_p5_beginning = (
+            '<?xml version="1.0"?>' + '\n' +
+            '<TEI xmlns="http://www.tei-c.org/ns/1.0">' + '\n' +
+            '  <teiHeader>' + '\n' +
+            '  </teiHeader>' + '\n' +
+            '  <text>' + '\n' +
+            '    <body>' + '\n'
+        )
+
+        return tei_p5_beginning
+
+    @staticmethod
+    def __convert_plain_text_to_tei_body(text):  # type: (str) -> str
+        paragraph_open = '<p>'
+        paragraph_close = '</p>'
+        new_line = '\n'
+
+        text = paragraph_open + text + paragraph_close
+        text = text.replace(new_line, paragraph_close + new_line + paragraph_open)
+
+        empty_paragraph_regex = r'[\s]*<p>[\s]*<\/p>[\s]*'
+        text = re.sub(empty_paragraph_regex, '', text)
+
+        joined_paragraph_regex = r'<\/p>[\s]*<p>'
+        text = re.sub(joined_paragraph_regex, paragraph_close + new_line + paragraph_open, text)
+
+        return text
+
+    @staticmethod
+    def __create_tei_p5_end():  # type: () -> str
+        tei_p5_end = (
+            '\n' +
+            '    </body>' + '\n' +
+            '  </text>' + '\n' +
+            '</TEI>'
+        )
+
+        return tei_p5_end

--- a/src/collaborative_platform/apps/files_management/file_conversions/recognized_types.py
+++ b/src/collaborative_platform/apps/files_management/file_conversions/recognized_types.py
@@ -5,7 +5,7 @@ class FileType(Enum):
     XML = 1
     CSV = 2
     TSV = 3
-    OTHER = 99
+    PLAIN_TEXT = 99
 
 
 class XMLType(Enum):

--- a/src/collaborative_platform/apps/files_management/helpers.py
+++ b/src/collaborative_platform/apps/files_management/helpers.py
@@ -234,11 +234,14 @@ def append_unifications(xml_content, file_version):  # type: (str, FileVersion) 
     return xml_content
 
 
-def create_certainty_elements_for_file_version(file_version, include_uncommitted=False, user=None):
-    # type: (FileVersion, bool, User) -> list
+def create_certainty_elements_for_file_version(file_version, include_uncommitted=False, user=None, for_annotator=False):
+    # type: (FileVersion, bool, User, bool) -> list
 
     if include_uncommitted and not user:
         raise ValueError("Argument 'include_uncommitted' require to fill a 'user' argument.")
+
+    if for_annotator and not include_uncommitted:
+        raise ValueError("Argument 'for_annotator' require to set a 'include_uncommitted' argument to 'True'.")
 
     cliques = Clique.objects.filter(
         Q(unifications__deleted_in_file_version__isnull=True)
@@ -248,7 +251,13 @@ def create_certainty_elements_for_file_version(file_version, include_uncommitted
         unifications__entity__file=file_version.file,
     ).distinct()
 
-    if include_uncommitted:
+    if include_uncommitted and for_annotator:
+        cliques = cliques.filter(
+            (Q(created_in_commit__isnull=True) & Q(created_in_annotator=False) & Q(created_by=user))
+            | (Q(created_in_commit__isnull=True) & Q(created_in_annotator=True))
+            | Q(created_in_commit__isnull=False)
+        )
+    elif include_uncommitted and not for_annotator:
         cliques = cliques.filter(
             (Q(created_in_commit__isnull=True) & Q(created_by=user))
             | Q(created_in_commit__isnull=False),
@@ -266,7 +275,13 @@ def create_certainty_elements_for_file_version(file_version, include_uncommitted
             deleted_on__isnull=True,
         )
 
-        if include_uncommitted:
+        if include_uncommitted and for_annotator:
+            unifications = unifications.filter(
+                (Q(created_in_commit__isnull=True) & Q(created_in_annotator=False) & Q(created_by=user))
+                | (Q(created_in_commit__isnull=True) & Q(created_in_annotator=True))
+                | Q(created_in_commit__isnull=False)
+            )
+        elif include_uncommitted and not for_annotator:
             unifications = unifications.filter(
                 (Q(created_in_commit__isnull=True) & Q(created_by=user))
                 | Q(created_in_commit__isnull=False),


### PR DESCRIPTION
Now adding to tag a reference to another tag create unification in database instead adding a `<certainty>` element in xml file. Unifications created in Annotator are automatically committed after pressing `Save current file` button.