### PR TITLE
Feature/annotator redesign

### DIFF
--- a/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
@@ -323,6 +323,20 @@ div#history-popup span.color{
     position: fixed;
     display: none;}
 
+#popup .title hr{
+  margin-top: 0;
+}
+
+#popup .author {
+    font-size: .8em;
+    color: var(--primary);
+    font-weight: bold;
+}
+
+#popup .tagId{
+  font-size: .9em; 
+}
+
 #popup-arrow{
     width: 20px;
     height: 20px;

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
@@ -58,6 +58,10 @@ page {
     z-index: 2;
 }
 
+#toolbar .form-control{
+  font-size: .7em;
+}
+
 #toolbar .toogle-button{
 	position: relative;
 	bottom: -6px;
@@ -496,5 +500,8 @@ div#history-popup span.color{
     #toolbar .nav-link{
       padding-top: .5rem;
       padding-bottom: .5rem;
+    }
+    #toolbar .form-control{
+      font-size: .875rem;
     }
 }

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
@@ -25,6 +25,7 @@ button span, #alert{
 /*#annotator-root{max-width: 23.7cm;}*/
 #versionLink:first-of-type{font-size: 0.7em;}
 .break-word {
+  font-size: 1.2em;
   display: flex;
   align-items: end;
   justify-content: space-between;
@@ -59,7 +60,7 @@ page {
 
 #toolbar .toogle-button{
 	position: relative;
-	bottom: -15px;
+	bottom: -6px;
 	z-index: 1;
 }
 #toolbar .toogle-button .btn-primary{
@@ -69,6 +70,8 @@ page {
     background-color: #f7f7f7;
     border-color: #dee2e6 #dee2e6 #f7f7f7;
     border-bottom: solid 1px #dee2e6;
+    padding-top: .2em;
+    padding-bottom: .2em;
 }
 #toolbar .nav-link.active{
     background-color: #fff;
@@ -88,6 +91,8 @@ page {
 .btn .active-show{display: none;}
 .btn.active .active-show{display: initial;}
 .btn.active .active-hide{display: none;}
+
+.btn{line-height: 1.2em;}
 
 #toolbar{
 	width: 23cm; 
@@ -134,6 +139,12 @@ page {
 #legend span.teiLegendElement,
 #legend span.certLegendElement{
     display:block;
+}
+
+#top-breadcrumb{
+  display: inline-block;
+  font-size: .8em;
+  margin-right: .5em;
 }
 
 #top-legend hr{margin-top: -.5em;}
@@ -237,8 +248,7 @@ input#references-autocomplete {
 }
 
 #history-container{
-    padding-top:10px;
-    padding-bottom:8px;
+    padding-top:7px;
 }
 
 #history.hovered{
@@ -455,10 +465,20 @@ div#history-popup span.color{
   margin-bottom: 12em;
 }
 
+#toolbar #header-card{padding-top: .6em;}
+
 @media (min-width: 1800px) {
+    .break-word {font-size: 1.4em;}
+    .btn{line-height: 1.5em;}
+    #toolbar .toogle-button{bottom: -15px;}
+    #toolbar #header-card{padding-top: 1rem;}
     #left-sidebar{max-width: 25%;}
     #annotator-root #legend,
     #annotator-root #left-sidebar{display: initial;}
     #top-legend, #top-breadcrumb{display: none;}
     #breadcrumb{display: initial;}
+    #toolbar .nav-link{
+      padding-top: .5rem;
+      padding-bottom: .5rem;
+    }
 }

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
@@ -12,6 +12,8 @@ button span, #alert{
   z-index: 1000;
 }
 
+#editor{padding-bottom: 15em;}
+
 #editor p,
 #editor div,
 #editor br{

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/css/main.css
@@ -467,6 +467,8 @@ div#history-popup span.color{
 
 #toolbar #header-card{padding-top: .6em;}
 
+*::before, *::after{pointer-events: none;}
+
 @media (min-width: 1800px) {
     .break-word {font-size: 1.4em;}
     .btn{line-height: 1.5em;}

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -117,7 +117,8 @@ var Tooltips = function(args){
 	function _createAnnotationDescription(attrs){
 		const categories = attrs.ana.value.split(' ').map(x=>x.split('#')[1]),
 			header = `${attrs.cert.value} ${categories.join(', ')} certainty`,
-			author = `( author : ${attrs.resp.value} )`;
+			author = `( author : ${attrs.resp.value} )`,
+			description = attrs.hasOwnProperty('description')?`<br/>Comment: ${attrs.description.value}`:'';
 		let target = 'Uncertain regarding the ';
 
 		if(attrs.locus.value == 'name') {
@@ -133,6 +134,7 @@ var Tooltips = function(args){
 			<i class="author">${author}</i><br/>
 			${target}<br/>
 			Proposed value : ${attrs.hasOwnProperty('assertedValue')?attrs.assertedValue.value:''}
+			${description}
 		`
 
 	}
@@ -143,12 +145,16 @@ var Tooltips = function(args){
 		Array.from(args.document.getElementsByTagName('teiHeader')[0].getElementsByTagName('certainty'), a=>a)
             .forEach(annotation=>{
                 annotation.attributes['target'].value.trim().split(" ").forEach(target=>{
-                    const id = args.XML_EXTRA_CHAR_SPACER+target.slice(1);
+                    const id = args.XML_EXTRA_CHAR_SPACER+target.slice(1),
+                    	attributes = annotation.attributes;
+                    if(annotation.children.length == 1)
+                    	attributes.description =  {value: annotation.children[0].textContent};
+
                     if(id != args.XML_EXTRA_CHAR_SPACER && document.getElementById(id) != null){   
                     	if(certaintyAnnotations.hasOwnProperty(id))
-                    		certaintyAnnotations[id].push(annotation.attributes);
+                    		certaintyAnnotations[id].push(attributes);
                     	else
-                    		certaintyAnnotations[id] = [annotation.attributes];
+                    		certaintyAnnotations[id] = [attributes];
                     }
                 })
             });

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -36,27 +36,38 @@ var Popup = function(args){
 			body: 'The body',
 			x: '50%',
 			y: '25%'
-		},args);
+		},args), 
+			popup = document.getElementById('popup');
 
-		document
-        	.getElementById('popup')
+		popup
         	.getElementsByClassName('card-title')[0]
         	.innerHTML = values.title;
 
-        document
-        	.getElementById('popup')
+        popup
         	.getElementsByClassName('card-subtitle')[0]
         	.innerHTML = values.subtitle;
 
-        document
-        	.getElementById('popup')
+        popup
         	.getElementsByClassName('card-text')[0]
         	.innerHTML = values.body;
 
-        document.getElementById('popup').style.setProperty('left',args.x);
-		document.getElementById('popup').style.setProperty('top',args.y);
+		popup.style.setProperty('display','initial');
+		const boundingRect = popup.getBoundingClientRect()
+		let x = '0px';
 
-		document.getElementById('popup').style.setProperty('display','initial');
+		if(args.x >= boundingRect.width/2)
+        	x = args.x - boundingRect.width/2 + 'px';
+
+        const scrollBarWidth = 16;
+        if(args.x >= (window.innerWidth - scrollBarWidth - boundingRect.width))
+        	x = window.innerWidth - scrollBarWidth - boundingRect.width + 'px';
+
+
+        popup.style.setProperty('left', x);
+		popup.style.setProperty('top',args.y);
+
+        const arrowLeft = Math.abs(boundingRect.x - args.x) + 'px';
+        document.getElementById('popup-arrow').style.setProperty('left', arrowLeft);
 	}
 
 	function _hidePopup(args){
@@ -223,14 +234,16 @@ var Tooltips = function(args){
 					if(tag_name == 'objectName' && document.getElementById('using-recipes-plugin').checked === false)
 						return 
 
+					const position = node.getBoundingClientRect();
+
 					self.publish('popup/render',{
 						title: (`<span class="teiLegendElement" id="${tag_name}">
 								<span class="color bg-${tag_name}"></span></span>`
 								+ node.textContent),
 						subtitle: subtitle,
 						body: body,
-						x: (e.clientX - 150)+'px',//(node.getBoundingClientRect().x+node.getBoundingClientRect().width/2 -150)+'px', 
-						y: (e.clientY + 40) +'px'
+						x: position.x + (position.width/2),//(node.getBoundingClientRect().x+node.getBoundingClientRect().width/2 -150)+'px', 
+						y: position.y + position.height*2 + 'px'
 					})
 				});
 				node.addEventListener('mouseout', ()=>self.publish('popup/hide',{}));

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -52,7 +52,7 @@ var Popup = function(args){
         	.innerHTML = values.body;
 
 		popup.style.setProperty('display','initial');
-		const boundingRect = popup.getBoundingClientRect()
+		const boundingRect = popup.getBoundingClientRect();
 		let x = '0px';
 
 		if(args.x >= boundingRect.width/2)
@@ -66,7 +66,8 @@ var Popup = function(args){
         popup.style.setProperty('left', x);
 		popup.style.setProperty('top',args.y);
 
-        const arrowLeft = Math.abs(boundingRect.x - args.x) + 'px';
+
+        const arrowLeft = Math.abs(popup.getBoundingClientRect().x - args.x) + 'px';
         document.getElementById('popup-arrow').style.setProperty('left', arrowLeft);
 	}
 

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -120,18 +120,19 @@ var Tooltips = function(args){
 			author = `( author : ${attrs.resp.value} )`;
 		let target = 'Uncertain regarding the ';
 
-		if(attrs.locus == 'name')
+		if(attrs.locus.value == 'name') {
 			target += 'tag name';
-		else if(attrs.hasOwnProperty('match'))
+		} else if(attrs.hasOwnProperty('match')) {
 			target += `${attrs.match.value.slice(1)} attribute`;
-		else
+		} else {
 			target += 'text content';
+		}
 
 		return `
 			${header}<br/>
 			<i class="author">${author}</i><br/>
 			${target}<br/>
-			Proposed value : ${attrs.assertedValue.value}
+			Proposed value : ${attrs.hasOwnProperty('assertedValue')?attrs.assertedValue.value:''}
 		`
 
 	}

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -204,6 +204,21 @@ var Tooltips = function(args){
 					`<span class="tagId">ID : ${original_tag_id}</span><br/>( ${tag_name} )`:
 					`( ${tag_name} )`;
 
+				if(original_tag_id != ''){
+					node.addEventListener('click', ()=>{
+						const args = {
+							selection: {
+								text: original_tag_id,
+								abs_positions: null,
+								by_id: true,
+								target: original_tag_id
+							}
+						}
+
+						self.publish('sidepanel/selection', args);
+					})
+				}
+
 				node.addEventListener('mouseenter', e=>{
 					if(tag_name == 'objectName' && document.getElementById('using-recipes-plugin').checked === false)
 						return 

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/websocket.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/utilities/websocket.js
@@ -32,10 +32,10 @@ const AnnotatorWebSocket = function(){
         let wsPrefix = (window.location.protocol === 'https:') ? 'wss://' : 'ws://';
         let port = '';
 
-        if (window.location.hostname === '0.0.0.0' || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
-        {
-            port = ':' + window.location.port
-        }
+        //if (window.location.hostname === '0.0.0.0' || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+        //{
+        //}
+        port = ':' + window.location.port
 
         socket = new WebSocket(wsPrefix + window.location.host.split(':')[0] + port + '/ws/close_reading/' + project_id + '_' + file_id + '/');
 

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -64,56 +64,36 @@
         <main role="main" class="col-md-8 col-lg-8 px-4 justify-content-center d-flex"> 
           <div id="toolbar-container" class="col-auto">
             <section id="toolbar">
-              <nav aria-label="breadcrumb" id="top-breadcrumb">
-                <ol class="breadcrumb bg-transparent">
-                  <a href="{{ origin_url }}" class="breadcrumb-item">{{ origin }}</a>
-                  <li class="breadcrumb-item active" aria-current="page">Close Reading</li>
-                </ol>
-              </nav>
               <div id="alert" class="hide" role="alert"></div>
-              <div class="card card-body">
-              <h3 class="break-word">
-    {#             Split file name into two parts: with and without extension#}
-                <span>
-                  <span id="fileTitleEditable" title="{{ file.name }}">{{ file.name |truncatechars:40}}</span>
-                  <a id='versionLink'  class='scripted'>Version: {{ file.version_number }}</a>
-    {#              % if file_revision:#}
-    {#                <small>&nbsp;${file_revision | h}</small>#}
-    {#              % endif#}
-                </span>
-                <button class="btn btn-outline-primary btn-sm" href="" id="saveFile">Save current file</button>
-              </h3>
-              <div id="history-container">
-                <div id="history">
-                  <span id="history-legend">Uncertainty</span>
-                  <div>
-                    <canvas></canvas>
-                    <hr/>
-                    <div id="versions"></div>
-                    <div id="version-toltip"></div>
-                    <div id="history-popup">
+              <div class="card card-body" id="header-card">
+                <div class="col px-0 justify-space-between">
+                  <h3 class="break-word">
+                    <span>
+                      <nav aria-label="breadcrumb" id="top-breadcrumb">
+                          <a href="{{ origin_url }}" class="breadcrumb-item">(Back to {{ origin }})</a>
+                      </nav>
+                      <span id="fileTitleEditable" title="{{ file.name }}">{{ file.name |truncatechars:40}}</span>
+                      <a id='versionLink'  class='scripted'>Version: {{ file.version_number }}</a>
+                    </span>
+                    <button class="btn btn-outline-primary btn-sm" href="" id="saveFile">Save current file</button>
+                  </h3>
+                </div>  
+                <div id="history-container">
+                  <div id="history">
+                    <span id="history-legend">Uncertainty</span>
+                    <div>
+                      <canvas></canvas>
+                      <hr/>
+                      <div id="versions"></div>
+                      <div id="version-toltip"></div>
+                      <div id="history-popup">
+                    </div>
                   </div>
                 </div>
               </div>
               </div>
-              </div>
                 <div class="collapse p-2" id="example" class="card card-body">
                   <div>
-                    <div id="visual-options" class="d-flex justify-content-between">
-                      <button id="display-annotations" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
-                        <span class="active-hide">Show</span><span class="active-show">Hide</span> annotations
-                      </button>
-                      <button id="display-uncertainty" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
-                        <span class="active-hide">Show</span><span class="active-show">Hide</span> uncertainty
-                      </button>
-                      <button id="color-annotations" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
-                        <span class="active-hide">Show</span><span class="active-show">Hide</span> color for annotations
-                      </button>
-                      <button id="color-uncertainty" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
-                        <span class="active-hide">Show</span><span class="active-show">Hide</span> color for uncertainty
-                      </button>
-                    </div>
-                    <hr>
                     <div class="toolbarRow" id="toolbar-controls">
                         <span class="toolbar-control" id="annotation-options">
                           <ul class="nav nav-tabs" id="tab-controls" role="tablist">
@@ -122,6 +102,9 @@
                             </li>
                             <li class="nav-item">
                               <a class="nav-link" id="annotating-tei" data-toggle="tab" href="#tei-tab" role="tab" aria-controls="tei-tab" aria-selected="false">Add TEI annotations</a>
+                            </li>
+                            <li class="nav-item">
+                              <a class="nav-link" id="visual-options-tab" data-toggle="tab" href="#visual-tab" role="tab" aria-controls="visual-tab" aria-selected="false">Visual settings</a>
                             </li>
                           </ul>
                           <div class="tab-content" id="annotation-form">
@@ -231,6 +214,22 @@
                                   <button class="btn btn-outline-success" id="create-tei-annotation">Create</button>
                                 </div>
                               </div>
+                            </div>
+                            <div class="tab-pane" id="visual-tab" role="tabpanel" aria-labelledby="visual-tab">
+                              <div id="visual-options" class="d-flex justify-content-between">
+                              <button id="display-annotations" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
+                                <span class="active-hide">Show</span><span class="active-show">Hide</span> annotations
+                              </button>
+                              <button id="display-uncertainty" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
+                                <span class="active-hide">Show</span><span class="active-show">Hide</span> uncertainty
+                              </button>
+                              <button id="color-annotations" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
+                                <span class="active-hide">Show</span><span class="active-show">Hide</span> color for annotations
+                              </button>
+                              <button id="color-uncertainty" class="btn btn-outline-primary btn-sm active" data-toggle="button" aria-pressed="true" pressed="true" autocomplete="false">
+                                <span class="active-hide">Show</span><span class="active-show">Hide</span> color for uncertainty
+                              </button>
+                            </div>
                             </div>
                           </div>
                           <!-- 

--- a/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
+++ b/src/collaborative_platform/apps/close_reading/templates/close_reading/close_reading.html
@@ -122,8 +122,8 @@
                                     <span class="help-tooltip" help="Specify wether the annotation refers to the tag name (<i>name</i>) or the text value (<i>value</i>)." />
                                   </label>
                                   <select class="form-control form-control-sm" id='locus'>
-                                    <option value="value">Value</option>
                                     <option value="name">Name</option>
+                                    <option value="value">Value</option>
                                   </select>
                                 </div>
                                 <div class="col">


### PR DESCRIPTION
Tooltips are now more descriptive and are placed based on the viewport span
in order to fit in smaller screens. The card and arrow's position is now 
determined by the position of the hovered element rather than the cursor; this
fixes misplacement issues for cursor interactions with the icons.

Users can now select an referenceable entity (a tag with id) by clicking in the tag
rather than re-selecting the text inside.

The size of the toolbar panel (both collapsed and extended) has been significantly 
reduced in order to offer more space to documents in smaller screens.

'Name' is now the default value for the locus input.