### PR TITLE
Feature/annotator selection text

### DIFF
--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/cert_list.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/cert_list.js
@@ -114,9 +114,12 @@ let CertaintyList = function(args){
 
 		const target = e.target.attributes['annotation-target'].value.split('#')[1];
 
+    const node = document.getElementById('xxxx'+target),
+      text = node==null?target:node.textContent;
+
 		const args = {
 			selection: {
-				text: target,
+				text,
 				abs_positions: null,
 				by_id: true,
 				target: target

--- a/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
+++ b/src/collaborative_platform/apps/close_reading/static/close_reading/js/src/tooltips.js
@@ -220,7 +220,7 @@ var Tooltips = function(args){
 					node.addEventListener('click', ()=>{
 						const args = {
 							selection: {
-								text: original_tag_id,
+								text: node.textContent,
 								abs_positions: null,
 								by_id: true,
 								target: original_tag_id


### PR DESCRIPTION
Now, when selecting entities present in the document via click interaction (either in the
document itself or in the side view), the tag content is shown in the panel rather than
the id.